### PR TITLE
Add bjet counters, update PATObjectCounter 

### DIFF
--- a/AnalysisTools/plugins/PATObjectCounter.cc
+++ b/AnalysisTools/plugins/PATObjectCounter.cc
@@ -43,32 +43,36 @@ private:
   virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
 
   const edm::EDGetTokenT<edm::View<T> > srcToken_;
-  const std::vector<std::string> cuts_;
+  const std::vector<std::string> cut_strings_;
   const std::vector<std::string> labels_;
+  std::vector<StringCutObjectSelector<T>> cuts_;
 };
 
 
 template<typename T>
 PATObjectCounter<T>::PATObjectCounter(const edm::ParameterSet& iConfig) :
   srcToken_(consumes<edm::View<T> >(iConfig.getParameter<edm::InputTag>("src"))),
-  cuts_(iConfig.exists("cuts") ?
+  cut_strings_(iConfig.exists("cuts") ?
              iConfig.getParameter<std::vector<std::string> >("cuts") :
              std::vector<std::string>()),
   labels_(iConfig.exists("labels") ?
              iConfig.getParameter<std::vector<std::string> >("labels") :
              std::vector<std::string>())
 {
-  for (const auto& label : labels_) 
-    { 
-      produces<int>(label);
-    }
-  
-  if(cuts_.size() != labels_.size())
+  if(cut_strings_.size() != labels_.size())
       throw cms::Exception("InvalidParams")
           << "You must supply an equal number of labels and cuts" << std::endl
           << "Given: labels_->size() == " << labels_.size()
-          << "; cuts_->size() == " << cuts_.size()
+          << "; cut_strings_->size() == " << cut_strings_.size()
           << std::endl;
+  size_t i = 0;
+  for (const auto& label : labels_) 
+    { 
+      produces<int>(label);
+      cuts_.push_back(cut_strings_[i]);
+      i++;
+    }
+  
 }
 
 
@@ -79,16 +83,15 @@ void PATObjectCounter<T>::produce(edm::Event& iEvent,
   edm::Handle<edm::View<T> > in;
   iEvent.getByToken(srcToken_, in);
   
-  for (size_t i = 0; i < cuts_.size(); i++) 
+  for (size_t i = 0; i < cut_strings_.size(); i++) 
     {
       std::unique_ptr<int> num(new int(0));
-      if (cuts_[i] != "")
+      if (cut_strings_[i] != "")
         {
-          StringCutObjectSelector<T> cut(cuts_[i]);
           for(size_t j = 0; j < in->size(); j++)
             {
-              if (cut(in->at(j)))
-                  *num += j;
+              if (cuts_[i](in->at(j)))
+                  (*num)++;
             }
         }
       else

--- a/AnalysisTools/plugins/PATObjectValueEmbedder.cc
+++ b/AnalysisTools/plugins/PATObjectValueEmbedder.cc
@@ -103,21 +103,29 @@ PATObjectValueEmbedder<T>::PATObjectValueEmbedder(const edm::ParameterSet& iConf
   if(intTokens_.size() != intLabels_.size())
     throw cms::Exception("InvalidParams")
       << "You must supply exactly one label for each int you want to embed" 
+      << "Given: intLabels_.size() == " << intLabels_.size()
+      << "; intTokens_.size() == " << intTokens_.size()
       << std::endl;
 
   if(boolTokens_.size() != boolLabels_.size())
     throw cms::Exception("InvalidParams")
       << "You must supply exactly one label for each bool you want to embed" 
+      << "Given: boolLabels_.size() == " << boolLabels_.size()
+      << "; boolTokens_.size() == " << boolTokens_.size()
       << std::endl;
 
   if(doubleTokens_.size() != doubleLabels_.size())
     throw cms::Exception("InvalidParams")
       << "You must supply exactly one label for each double you want to embed" 
+      << "Given: doubleLabels_.size() == " << doubleLabels_.size()
+      << "; doubleTokens_.size() == " << doubleTokens_.size()
       << std::endl;
 
   if(floatTokens_.size() != floatLabels_.size())
     throw cms::Exception("InvalidParams")
       << "You must supply exactly one label for each float you want to embed" 
+      << "Given: floatLabels_.size() == " << floatLabels_.size()
+      << "; floatTokens_.size() == " << floatTokens_.size()
       << std::endl;
 }
 

--- a/AnalysisTools/python/templates/BJetCounters.py
+++ b/AnalysisTools/python/templates/BJetCounters.py
@@ -28,7 +28,7 @@ class BJetCounters(AnalysisFlowBase):
                 "PATJetCounter",
                 src = step.getObjTag('j'),
                 labels = cms.vstring(*['nJet'+label for label in jetCounters.keys()]),
-                cuts = cms.vstring(*[x for x in jetCounters.values()])#*list(jetCounters.values())),
+                cuts = cms.vstring(*[jetCounters[key] for key in jetCounters.keys()])
                 )
             step.addModule("jetCounter", mod)
 

--- a/AnalysisTools/python/templates/BJetCounters.py
+++ b/AnalysisTools/python/templates/BJetCounters.py
@@ -1,0 +1,48 @@
+from UWVV.AnalysisTools.AnalysisFlowBase import AnalysisFlowBase
+
+from UWVV.Utilities.helpers import parseChannels
+
+import FWCore.ParameterSet.Config as cms
+
+
+class BJetCounters(AnalysisFlowBase):
+    def __init__(self, *args, **kwargs):
+        super(BJetCounters, self).__init__(*args, **kwargs)
+
+
+    def makeAnalysisStep(self, stepName, **inputs):
+        step = super(BJetCounters, self).makeAnalysisStep(stepName, **inputs)
+        
+        if stepName == 'initialStateEmbedding':
+            jetCounters = {'PassJPL' : '? bDiscriminator("pfJetProbabilityBJetTags")>0.245 ? 1 : 0',
+                "PassJPM" : '? bDiscriminator("pfJetProbabilityBJetTags")>0.515 ? 1 : 0',
+                "PassJPT" : '? bDiscriminator("pfJetProbabilityBJetTags")>0.760 ? 1 : 0',
+                "PassCSVv2L" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.460 ? 1 : 0',
+                "PassCSVv2M" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.800 ? 1 : 0',
+                "PassCSVv2T" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.935 ? 1 : 0',
+                "PassCMVAv2L" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>-0.715 ? 1 : 0',
+                "PassCMVAv2M" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>0.185 ? 1 : 0',
+                "PassCMVAv2T" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>0.875 ? 1 : 0',
+            }
+            mod = cms.EDProducer(
+                "PATJetCounter",
+                src = step.getObjTag('j'),
+                labels = cms.string(['nJet'+label for label in jetCounters.keys()]),
+                cuts = cms.untracked.string(list(jetCounters.values())),
+                )
+            step.addModule(label+"Counter", mod)
+
+            labels = ['n'+name for name in jetCounters.keys()]
+            tags = [cms.InputTag(name+"Counter:n"+name) for name in jetCounters.keys()]
+
+            for chan in parseChannels('zl'):
+                countEmbedding = cms.EDProducer(
+                    'PATCompositeCandidateValueEmbedder',
+                    src = step.getObjTag(chan),
+                    intLabels = cms.vstring(*labels),
+                    intSrc = cms.VInputTag(*tags),
+                    )
+                step.addModule(chan+'JetCountEmbedding', countEmbedding, chan)
+
+        return step
+

--- a/AnalysisTools/python/templates/BJetCounters.py
+++ b/AnalysisTools/python/templates/BJetCounters.py
@@ -14,26 +14,26 @@ class BJetCounters(AnalysisFlowBase):
         step = super(BJetCounters, self).makeAnalysisStep(stepName, **inputs)
         
         if stepName == 'initialStateEmbedding':
-            jetCounters = {'PassJPL' : '? bDiscriminator("pfJetProbabilityBJetTags")>0.245 ? 1 : 0',
-                "PassJPM" : '? bDiscriminator("pfJetProbabilityBJetTags")>0.515 ? 1 : 0',
-                "PassJPT" : '? bDiscriminator("pfJetProbabilityBJetTags")>0.760 ? 1 : 0',
-                "PassCSVv2L" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.460 ? 1 : 0',
-                "PassCSVv2M" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.800 ? 1 : 0',
-                "PassCSVv2T" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.935 ? 1 : 0',
-                "PassCMVAv2L" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>-0.715 ? 1 : 0',
-                "PassCMVAv2M" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>0.185 ? 1 : 0',
-                "PassCMVAv2T" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>0.875 ? 1 : 0',
+            jetCounters = {'JPL' : '? bDiscriminator("pfJetProbabilityBJetTags")>0.245 ? 1 : 0',
+                "JPM" : '? bDiscriminator("pfJetProbabilityBJetTags")>0.515 ? 1 : 0',
+                "JPT" : '? bDiscriminator("pfJetProbabilityBJetTags")>0.760 ? 1 : 0',
+                "CSVv2L" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.460 ? 1 : 0',
+                "CSVv2M" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.800 ? 1 : 0',
+                "CSVv2T" : '? bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>0.935 ? 1 : 0',
+                "CMVAv2L" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>-0.715 ? 1 : 0',
+                "CMVAv2M" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>0.185 ? 1 : 0',
+                "CMVAv2T" : '? bDiscriminator("pfCombinedMVAV2BJetTags")>0.875 ? 1 : 0',
             }
             mod = cms.EDProducer(
                 "PATJetCounter",
                 src = step.getObjTag('j'),
-                labels = cms.string(['nJet'+label for label in jetCounters.keys()]),
-                cuts = cms.untracked.string(list(jetCounters.values())),
+                labels = cms.vstring(*['nJet'+label for label in jetCounters.keys()]),
+                cuts = cms.vstring(*[x for x in jetCounters.values()])#*list(jetCounters.values())),
                 )
-            step.addModule(label+"Counter", mod)
+            step.addModule("jetCounter", mod)
 
-            labels = ['n'+name for name in jetCounters.keys()]
-            tags = [cms.InputTag(name+"Counter:n"+name) for name in jetCounters.keys()]
+            labels = ['nJet'+name for name in jetCounters.keys()]
+            tags = [cms.InputTag("jetCounter:nJet"+name) for name in jetCounters.keys()]
 
             for chan in parseChannels('zl'):
                 countEmbedding = cms.EDProducer(

--- a/AnalysisTools/python/templates/WZLeptonCounters.py
+++ b/AnalysisTools/python/templates/WZLeptonCounters.py
@@ -14,33 +14,28 @@ class WZLeptonCounters(AnalysisFlowBase):
         step = super(WZLeptonCounters, self).makeAnalysisStep(stepName, **inputs)
         
         if stepName == 'initialStateEmbedding':
-            muCounters = {"tightMuonCounter" : "TightMuon",
-                          "medMuonCounter" : "MediumMuonICHEP",
-                          }
-            for moduleName, cut in muCounters.iteritems():
-                mod = cms.EDProducer(
-                    "PATMuonCounter",
-                    src = step.getObjTag('m'),
-                    labels = cms.vstring(cut),
-                    cuts = cms.vstring('userInt("is%s")' % cut),
-                    )
-                step.addModule(moduleName, mod)
+            muCounters = ["TightMuon", "MediumMuonICHEP",]
+                         
+            mod = cms.EDProducer(
+                "PATMuonCounter",
+                src = step.getObjTag('m'),
+                labels = cms.vstring(*[label for label in muCounters]),
+                cuts = cms.vstring(*['userInt("is%s")' % label for label in muCounters]),
+                )
+            step.addModule("muCounter", mod)
 
-            eCounters = {"tightElectronCounter" : "CBVIDtight",
-                         "medElectronCounter" : "CBVIDmedium",
-                         "looseElectronCounter" :"CBVIDloose",
-                         }
-            for moduleName, cut in eCounters.iteritems():
-                mod = cms.EDProducer(
-                    "PATElectronCounter",
-                    src = step.getObjTag('e'),
-                    labels = cms.vstring(cut),
-                    cuts = cms.vstring('userFloat("is%s") > 0.5' % cut),
-                    )
-                step.addModule(moduleName, mod)
+            eCounters = ["CBVIDtight", "CBVIDmedium","CBVIDloose",]
+                         
+            mod = cms.EDProducer(
+                "PATElectronCounter",
+                src = step.getObjTag('e'),
+                labels = cms.vstring(*[label for label in eCounters]),
+                cuts = cms.vstring(*['userFloat("is%s") > 0.5' % label for label in eCounters]),
+                )
+            step.addModule("elecCounter", mod)
 
-            counters = {'n'+label : name+':'+label for name, label in muCounters.iteritems()}
-            counters.update({'n'+label+'Elec' : name+':'+label for name, label in eCounters.iteritems()})
+            counters = {'n'+label : 'muCounter:'+label for label in muCounters}
+            counters.update({'n'+label+'Elec' : 'elecCounter:'+label for label in eCounters})
 
             labels = list(counters.keys())
             tags = [cms.InputTag(counters[label]) for label in labels]

--- a/AnalysisTools/python/templates/WZLeptonCounters.py
+++ b/AnalysisTools/python/templates/WZLeptonCounters.py
@@ -21,8 +21,8 @@ class WZLeptonCounters(AnalysisFlowBase):
                 mod = cms.EDProducer(
                     "PATMuonCounter",
                     src = step.getObjTag('m'),
-                    label = cms.string(cut),
-                    cut = cms.untracked.string('userInt("is%s")' % cut),
+                    labels = cms.vstring(cut),
+                    cuts = cms.vstring('userInt("is%s")' % cut),
                     )
                 step.addModule(moduleName, mod)
 
@@ -34,8 +34,8 @@ class WZLeptonCounters(AnalysisFlowBase):
                 mod = cms.EDProducer(
                     "PATElectronCounter",
                     src = step.getObjTag('e'),
-                    label = cms.string(cut),
-                    cut = cms.untracked.string('userFloat("is%s") > 0.5' % cut),
+                    labels = cms.vstring(cut),
+                    cuts = cms.vstring('userFloat("is%s") > 0.5' % cut),
                     )
                 step.addModule(moduleName, mod)
 

--- a/AnalysisTools/python/templates/ZZLeptonCounters.py
+++ b/AnalysisTools/python/templates/ZZLeptonCounters.py
@@ -24,18 +24,18 @@ class ZZLeptonCounters(AnalysisFlowBase):
             countTags = []
             countLabels = []
             for lep in 'e','m':
-                for name, cut in counters.iteritems():
-                    label = 'nZZ'+name+getObjName(lep, True)+'s'
-                    countLabels.append(label)
-                    mod = cms.EDProducer(
-                        "PAT{}Counter".format(getObjName(lep, True)),
-                        src = step.getObjTag(lep),
-                        labels = cms.vstring(label),
-                        cuts = cms.vstring(cut),
-                        )
-                    step.addModule(label, mod)
+                labels = ['nZZ'+name+getObjName(lep, True)+'s' for name in counters.keys()]
+                countLabels += labels
+                mod = cms.EDProducer(
+                    "PAT{}Counter".format(getObjName(lep, True)),
+                    src = step.getObjTag(lep),
+                    labels = cms.vstring(*labels),
+                    cuts = cms.vstring(*[counters[label] for label in counters.keys()]),
+                    )
+                moduleName = 'zz{0}Counter'.format('Elec' if lep == 'e' else 'Mu')
+                step.addModule(moduleName, mod)
 
-                    countTags.append(cms.InputTag('{0}:{0}'.format(label)))
+                countTags += [cms.InputTag('{name}:{label}'.format(name=moduleName,label=l)) for l in labels]
 
             for chan in parseChannels('zz')+parseChannels('zl')+parseChannels('z'):
                 if chan not in step.outputs:

--- a/AnalysisTools/python/templates/ZZLeptonCounters.py
+++ b/AnalysisTools/python/templates/ZZLeptonCounters.py
@@ -30,8 +30,8 @@ class ZZLeptonCounters(AnalysisFlowBase):
                     mod = cms.EDProducer(
                         "PAT{}Counter".format(getObjName(lep, True)),
                         src = step.getObjTag(lep),
-                        label = cms.string(label),
-                        cut = cms.untracked.string(cut),
+                        labels = cms.vstring(label),
+                        cuts = cms.vstring(cut),
                         )
                     step.addModule(label, mod)
 

--- a/Ntuplizer/python/templates/countBranches.py
+++ b/Ntuplizer/python/templates/countBranches.py
@@ -13,6 +13,24 @@ wzCountBranches = cms.PSet(
                                 'userInt("nTightMuon") : 999'),
         nMediumMuonICHEP = cms.string('? hasUserInt("nMediumMuonICHEP") ? '
                                       'userInt("nMediumMuonICHEP") : 999'),
+        nPassJPL = cms.string('? hasUserInt("nPassJPL") ? '
+                              'userInt("nPassJPL") : 999'),
+        nPassJPM = cms.string('? hasUserInt("nPassJPM") ? ' 
+                              'userInt("nPassJPM") : -999'),
+        nPassJPT = cms.string('? hasUserInt("nPassJPT") ? '
+                              'userInt("nPassJPT") : -999'),
+        nPassCSVv2L = cms.string('? hasUserInt("nPassCSVv2L") ? '
+                              'userInt("nPassCSVv2L") : -999'),
+        nPassCSVv2M = cms.string('? hasUserInt("nPassCSVv2M") ? '
+                                 'userInt("nPassCSVv2M") : -999'),
+        nPassCSVv2T = cms.string('? hasUserInt("nPassCSVv2T") ? '
+                                 'userInt("nPassCSVv2T") : -999'),
+        nPassCMVAv2L = cms.string('? hasUserInt("nPassCMVAv2L") ? '
+                                  'userInt("nPassCMVAv2L") : -999'),
+        nPassCMVAv2M = cms.string('? hasUserInt("nPassCMVAv2M") ? '
+                                  'userInt("nPassCMVAv2M") : -999'),
+        nPassCMVAv2T = cms.string('? hasUserInt("nPassCMVAv2T") ? '
+                                  'userInt("nPassCMVAv2T") : -999'),
         ),
     )
 

--- a/Ntuplizer/python/templates/countBranches.py
+++ b/Ntuplizer/python/templates/countBranches.py
@@ -13,24 +13,24 @@ wzCountBranches = cms.PSet(
                                 'userInt("nTightMuon") : 999'),
         nMediumMuonICHEP = cms.string('? hasUserInt("nMediumMuonICHEP") ? '
                                       'userInt("nMediumMuonICHEP") : 999'),
-        nPassJPL = cms.string('? hasUserInt("nPassJPL") ? '
-                              'userInt("nPassJPL") : 999'),
-        nPassJPM = cms.string('? hasUserInt("nPassJPM") ? ' 
-                              'userInt("nPassJPM") : -999'),
-        nPassJPT = cms.string('? hasUserInt("nPassJPT") ? '
-                              'userInt("nPassJPT") : -999'),
-        nPassCSVv2L = cms.string('? hasUserInt("nPassCSVv2L") ? '
-                              'userInt("nPassCSVv2L") : -999'),
-        nPassCSVv2M = cms.string('? hasUserInt("nPassCSVv2M") ? '
-                                 'userInt("nPassCSVv2M") : -999'),
-        nPassCSVv2T = cms.string('? hasUserInt("nPassCSVv2T") ? '
-                                 'userInt("nPassCSVv2T") : -999'),
-        nPassCMVAv2L = cms.string('? hasUserInt("nPassCMVAv2L") ? '
-                                  'userInt("nPassCMVAv2L") : -999'),
-        nPassCMVAv2M = cms.string('? hasUserInt("nPassCMVAv2M") ? '
-                                  'userInt("nPassCMVAv2M") : -999'),
-        nPassCMVAv2T = cms.string('? hasUserInt("nPassCMVAv2T") ? '
-                                  'userInt("nPassCMVAv2T") : -999'),
+        nJetJPL = cms.string('? hasUserInt("nJetJPL") ? '
+                              'userInt("nJetJPL") : 999'),
+        nJetJPM = cms.string('? hasUserInt("nJetJPM") ? ' 
+                              'userInt("nJetJPM") : -999'),
+        nJetJPT = cms.string('? hasUserInt("nJetJPT") ? '
+                              'userInt("nJetJPT") : -999'),
+        nJetCSVv2L = cms.string('? hasUserInt("nJetCSVv2L") ? '
+                              'userInt("nJetCSVv2L") : -999'),
+        nJetCSVv2M = cms.string('? hasUserInt("nJetCSVv2M") ? '
+                                 'userInt("nJetCSVv2M") : -999'),
+        nJetCSVv2T = cms.string('? hasUserInt("nJetCSVv2T") ? '
+                                 'userInt("nJetCSVv2T") : -999'),
+        nJetCMVAv2L = cms.string('? hasUserInt("nJetCMVAv2L") ? '
+                                  'userInt("nJetCMVAv2L") : -999'),
+        nJetCMVAv2M = cms.string('? hasUserInt("nJetCMVAv2M") ? '
+                                  'userInt("nJetCMVAv2M") : -999'),
+        nJetCMVAv2T = cms.string('? hasUserInt("nJetCMVAv2T") ? '
+                                  'userInt("nJetCMVAv2T") : -999'),
         ),
     )
 

--- a/Ntuplizer/python/templates/muonBranches.py
+++ b/Ntuplizer/python/templates/muonBranches.py
@@ -41,9 +41,9 @@ muonBranches = cms.PSet(
         IsTracker = cms.string('IsTracker'),
         IsLooseMuon = cms.string('isLooseMuon'),
         IsMediumMuon = cms.string('isMediumMuon'),
-        isTightMuon = cms.string('? hasUserInt("isTightMuon") ? '
+        IsTightMuon = cms.string('? hasUserInt("isTightMuon") ? '
                                  'userInt("isTightMuon") : 0'),
-        isMediumMuonICHEP = cms.string('? hasUserInt("isMediumMuonICHEP") ?'
+        IsMediumMuonICHEP = cms.string('? hasUserInt("isMediumMuonICHEP") ?'
                                        'userInt("isMediumMuonICHEP") : 0'),
 
         HighPtID = cms.string('? hasUserFloat("ZZIDPassHighPt") ? '

--- a/Ntuplizer/test/ntuplize_cfg.py
+++ b/Ntuplizer/test/ntuplize_cfg.py
@@ -219,6 +219,9 @@ elif zl or z:
 
         from UWVV.AnalysisTools.templates.WZLeptonCounters import WZLeptonCounters
         FlowSteps.append(WZLeptonCounters)
+        
+        from UWVV.AnalysisTools.templates.BJetCounters import BJetCounters
+        FlowSteps.append(BJetCounters)
 
         from UWVV.Ntuplizer.templates.countBranches import wzCountBranches
         extraInitialStateBranches.append(wzCountBranches)


### PR DESCRIPTION
Added counters for number of jets passing various b-jet criteria. Also modified PATObjectCounter to take a list of labels and collections since loading the collection and counting for a single ID is inefficient when checking one collection with multiple IDs. Updated WZLeptonCounters and ZZLeptonCounters to work with this change. 

@nwoods , can you check that this didn't change the behavior of counters for your IDs? It really shouldn't unless I made a dumb mistake.
