### PR TITLE
Updates for data in CMSSW_9_4_X

### DIFF
--- a/AnalysisTools/plugins/DressedGenParticlesProducer.cc
+++ b/AnalysisTools/plugins/DressedGenParticlesProducer.cc
@@ -20,7 +20,7 @@ class DressedGenParticlesProducer : public edm::EDProducer {
     private:
         edm::EDGetTokenT<reco::GenParticleCollection> baseCollectionToken_;
         edm::EDGetTokenT<reco::GenParticleCollection> associatesToken_;
-        double dRmax_;
+        const double dRmax_;
 };
 
 DressedGenParticlesProducer::DressedGenParticlesProducer(
@@ -34,7 +34,7 @@ DressedGenParticlesProducer::DressedGenParticlesProducer(
 }
 
 void DressedGenParticlesProducer::produce(edm::Event& event, const edm::EventSetup& es) {
-    std::auto_ptr<std::vector<DressedGenParticle> > dressedCollection(new std::vector<DressedGenParticle>);
+    std::unique_ptr<std::vector<DressedGenParticle> > dressedCollection = std::make_unique<std::vector<DressedGenParticle> >();
 
     edm::Handle<reco::GenParticleCollection> baseCollection;
     event.getByToken(baseCollectionToken_, baseCollection);
@@ -54,7 +54,7 @@ void DressedGenParticlesProducer::produce(edm::Event& event, const edm::EventSet
     //        {return part1.pt() > part2.pt();});
         //GreaterByPt<reco::Candidate>());
 
-    event.put(dressedCollection);
+    event.put(std::move(dressedCollection));
 }
 bool DressedGenParticlesProducer::allUniqueAssociates(
         reco::CandidateCollection& dressedParticles) {

--- a/AnalysisTools/plugins/MiniAODFSRPhotonProducer.cc
+++ b/AnalysisTools/plugins/MiniAODFSRPhotonProducer.cc
@@ -50,7 +50,7 @@ MiniAODFSRPhotonProducer::~MiniAODFSRPhotonProducer()
 }
 void MiniAODFSRPhotonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  std::auto_ptr<reco::PFCandidateCollection> comp( new reco::PFCandidateCollection );
+  std::unique_ptr<reco::PFCandidateCollection> comp = std::make_unique<reco::PFCandidateCollection>();
   edm::Handle<reco::CandidateView> cands;
   iEvent.getByToken(srcCands_, cands);
   edm::Handle<edm::View<pat::Muon> > muons;
@@ -79,7 +79,7 @@ void MiniAODFSRPhotonProducer::produce(edm::Event& iEvent, const edm::EventSetup
 	    }
 	}
     }
-  iEvent.put( comp );
+  iEvent.put( std::move(comp) );
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(MiniAODFSRPhotonProducer);

--- a/AnalysisTools/plugins/PATJetFSRCleaner.cc
+++ b/AnalysisTools/plugins/PATJetFSRCleaner.cc
@@ -59,7 +59,7 @@ private:
               std::vector<CandPtr>& addTo) const;
   bool selectFSRLep(const ElecPtr& e) const;
   bool selectFSRLep(const MuonPtr& m) const;
-  
+
   //// Data
   edm::EDGetTokenT<JetView> collectionTokenJ;
   edm::EDGetTokenT<ElecView> collectionTokenE;
@@ -78,13 +78,13 @@ private:
 
 
 PATJetFSRCleaner::PATJetFSRCleaner(const edm::ParameterSet& iConfig):
-  collectionTokenJ(consumes<JetView>(iConfig.exists("src") ? 
+  collectionTokenJ(consumes<JetView>(iConfig.exists("src") ?
                                       iConfig.getParameter<edm::InputTag>("src") :
                                       edm::InputTag("slimmedJets"))),
-  collectionTokenE(consumes<ElecView>(iConfig.exists("srcE") ? 
+  collectionTokenE(consumes<ElecView>(iConfig.exists("srcE") ?
                                       iConfig.getParameter<edm::InputTag>("srcE") :
                                       edm::InputTag("slimmedElectrons"))),
-  collectionTokenM(consumes<MuonView>(iConfig.exists("srcMu") ? 
+  collectionTokenM(consumes<MuonView>(iConfig.exists("srcMu") ?
                                       iConfig.getParameter<edm::InputTag>("srcMu") :
                                       edm::InputTag("slimmedMuons"))),
   fsrElecSelection(iConfig.exists("fsrElecSelection") ?
@@ -116,8 +116,8 @@ void PATJetFSRCleaner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   std::vector<CandPtr> fsr = getFSR(elecsIn, muonsIn);
 
-  std::auto_ptr<std::vector<Jet> > out = 
-    std::auto_ptr<std::vector<Jet> >(new std::vector<Jet>);
+  std::unique_ptr<std::vector<Jet> > out =
+    std::make_unique<std::vector<Jet> >();
 
   for(size_t iJ = 0; iJ < jetsIn->size(); ++iJ)
     {
@@ -133,11 +133,11 @@ void PATJetFSRCleaner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
         out->push_back(*jet);
     }
 
-  iEvent.put(out);
+  iEvent.put(std::move(out));
 }
-    
 
-std::vector<CandPtr> 
+
+std::vector<CandPtr>
 PATJetFSRCleaner::getFSR(const edm::Handle<ElecView>& elecs,
                          const edm::Handle<MuonView>& muons) const
 {

--- a/Ntuplizer/interface/FunctionLibrary.h
+++ b/Ntuplizer/interface/FunctionLibrary.h
@@ -963,7 +963,7 @@ namespace
         addTo["MissingHits"] =
           std::function<FType>([](const edm::Ptr<T>& obj, uwvv::EventInfo& evt, const std::string& option)
                                {
-                                 return obj->gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS);
+                                 return obj->gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS);
                                });
       }
     };

--- a/Ntuplizer/python/templates/triggerBranches.py
+++ b/Ntuplizer/python/templates/triggerBranches.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 
 
 triggerBranches = cms.PSet(
-    trigNames = cms.vstring('doubleMu', 'doubleMuDZ', 'doubleE',
-                            'singleESingleMu', 'singleMuSingleE',
-                            'tripleE', 'doubleESingleMu', 'doubleMuSingleE',
-                            'tripleMu', 'singleE', 'singleIsoMu',
-                            'singleIsoMu20', 'singleMu',),
+    trigNames = cms.vstring(),# 'doubleMu', 'doubleMuDZ', 'doubleE',
+                              # 'singleESingleMu', 'singleMuSingleE',
+                              # 'tripleE', 'doubleESingleMu', 'doubleMuSingleE',
+                              # 'tripleMu', 'singleE', 'singleIsoMu',
+                              # 'singleIsoMu20', 'singleMu',),
     doubleMuPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v[0-9]+',
                                 'HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v[0-9]+'),
     doubleMuDZPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v[0-9]+',

--- a/Ntuplizer/test/ntuplize_cfg.py
+++ b/Ntuplizer/test/ntuplize_cfg.py
@@ -31,7 +31,7 @@ options.register('isMC', 1,
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "1 if simulation, 0 if data")
-options.register('eCalib', 1,
+options.register('eCalib', 0,
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "1 if electron energy corrections are desired")
@@ -468,4 +468,3 @@ for chan in channels:
 p = flow.getPath()
 p += process.treeSequence
 
-process.schedule.append(p)

--- a/Ntuplizer/test/printZZCands_cfg.py
+++ b/Ntuplizer/test/printZZCands_cfg.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from UWVV.AnalysisTools.analysisFlowMaker import createFlow
-from UWVV.AnalysisTools.templates.ElectronBaseFlow import ElectronBaseFlow 
+from UWVV.AnalysisTools.templates.ElectronBaseFlow import ElectronBaseFlow
 from UWVV.AnalysisTools.templates.MuonBaseFlow import MuonBaseFlow
 from UWVV.AnalysisTools.templates.ZZInitialStateBaseFlow import ZZInitialStateBaseFlow
-    
+
 
 process = cms.Process("PrintZZ")
 
@@ -21,7 +21,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 100
 
 process.source = cms.Source(
     "PoolSource",
-    fileNames = cms.untracked.vstring('/store/mc/RunIIFall15MiniAODv2/GluGluHToZZTo4L_M2500_13TeV_powheg2_JHUgenV6_pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/60000/02C0EC1D-F3E4-E511-ADCA-AC162DA603B4.root'),
+    fileNames = cms.untracked.vstring('/store/data/Run2017C/MuonEG/MINIAOD/PromptReco-v3/000/300/742/00000/0A1C877F-617E-E711-A3F8-02163E01A332.root'),
     )
 
 process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(100))
@@ -35,17 +35,17 @@ initialStateFlow = InitialStateFlowClass('initialStateFlow', process,
 
 process.print4ECands = cms.EDAnalyzer(
     'CandidatePrinter',
-    src = cms.InputTag(initialStateFlow.finalObjTag('zz4e')),
+    src = initialStateFlow.finalObjTag('eeee'),
     )
 
 process.print2E2MuCands = cms.EDAnalyzer(
     'CandidatePrinter',
-    src = cms.InputTag(initialStateFlow.finalObjTag('zz2e2m')),
+    src = initialStateFlow.finalObjTag('eemm'),
     )
 
 process.print4MuCands = cms.EDAnalyzer(
     'CandidatePrinter',
-    src = cms.InputTag(initialStateFlow.finalObjTag('zz4m')),
+    src = initialStateFlow.finalObjTag('mmmm'),
     )
 
 process.printCands = cms.EndPath(

--- a/recipe/setup.sh
+++ b/recipe/setup.sh
@@ -36,14 +36,14 @@ fi
 
 pushd $CMSSW_BASE/src
 
-if [ ! -d ./EgammaAnalysis ]; then
-    echo "Setting up electron energy scale corrections"
-    git cms-merge-topic rafaellopesdesa:EgammaAnalysis80_EGMSmearer_Moriond17_23Jan
-
-    pushd EgammaAnalysis/ElectronTools/data
-    git clone https://github.com/ECALELFS/ScalesSmearings.git
-    popd
-fi
+# if [ ! -d ./EgammaAnalysis ]; then
+#     echo "Setting up electron energy scale corrections"
+#     git cms-merge-topic rafaellopesdesa:EgammaAnalysis80_EGMSmearer_Moriond17_23Jan
+#
+#     pushd EgammaAnalysis/ElectronTools/data
+#     git clone https://github.com/ECALELFS/ScalesSmearings.git
+#     popd
+# fi
 
 if [ "$HZZ" ]; then
 


### PR DESCRIPTION
Updates to make things work in 9_4_X. Some things are basic changes we should have made long ago (I thought we had already replaced all the `std::auto_ptr`s with `std::unique_ptr`s but I guess not), some are probably fine but need to be checked (someone should confirm that `HitPattern::numberOfAllHits()` is equivalent to the old `HitPattern::numberOfHits()`), and some are big but temporary while the 9_4_X situation gets sorted out (all triggers are disabled, new MET filter stuff by @kdlong is too).